### PR TITLE
deprecate Crate#asReward.

### DIFF
--- a/src/main/java/com/hazebyte/crate/api/claim/ClaimRegistrar.java
+++ b/src/main/java/com/hazebyte/crate/api/claim/ClaimRegistrar.java
@@ -1,5 +1,6 @@
 package com.hazebyte.crate.api.claim;
 
+import com.hazebyte.crate.api.crate.Crate;
 import com.hazebyte.crate.api.crate.reward.Reward;
 import org.bukkit.OfflinePlayer;
 import org.bukkit.entity.Player;
@@ -16,6 +17,8 @@ import java.util.concurrent.CompletableFuture;
 public interface ClaimRegistrar {
 
     CompletableFuture<Claim> addClaim(OfflinePlayer player, Reward... rewards);
+
+    CompletableFuture<Claim> addClaim(OfflinePlayer player, Crate crate, int amount);
 
     CompletableFuture<Void> removeClaim(Claim claim) throws IOException;
 

--- a/src/main/java/com/hazebyte/crate/api/crate/Crate.java
+++ b/src/main/java/com/hazebyte/crate/api/crate/Crate.java
@@ -3,6 +3,7 @@ package com.hazebyte.crate.api.crate;
 import com.hazebyte.crate.api.crate.reward.Reward;
 import com.hazebyte.crate.api.effect.Category;
 import org.bukkit.Location;
+import org.bukkit.OfflinePlayer;
 import org.bukkit.configuration.serialization.ConfigurationSerializable;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
@@ -141,11 +142,13 @@ public interface Crate extends ConfigurationSerializable {
 
     /**
      * Returns a reward that gives the user this crate.
-     *
+     * 
+     * @deprecated use {@link com.hazebyte.crate.api.claim.ClaimRegistrar#addClaim(OfflinePlayer, Crate, int)}
      * @param name The player's name to give the reward to.
      * @param amount The amount to give.
      * @return A reward with this crate as a reward.
      */
+    @Deprecated
     Reward asReward(String name, int amount);
 
     /**


### PR DESCRIPTION
The method is primarily used for claims internally. The method signature with the name can be confusing to folks. For folks who want to give a claim that is a Crate, use ClaimRegistrar#addClaim